### PR TITLE
Fix deprecated SwitchDevice to SwitchEntity

### DIFF
--- a/custom_components/philips_ambilight+hue/switch.py
+++ b/custom_components/philips_ambilight+hue/switch.py
@@ -4,7 +4,7 @@ import requests
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.switch import (
-    DOMAIN, PLATFORM_SCHEMA, SwitchDevice, ENTITY_ID_FORMAT)
+    DOMAIN, PLATFORM_SCHEMA, SwitchEntity, ENTITY_ID_FORMAT)
 from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_ID, STATE_OFF, STATE_STANDBY, STATE_ON)
 from requests.auth import HTTPDigestAuth
 from requests.adapters import HTTPAdapter
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     nodeId = config.get(CONF_ID)
     add_devices([AmbiHue(name, host, user, password, nodeId)])
 
-class AmbiHue(SwitchDevice):
+class AmbiHue(SwitchEntity):
 
     def __init__(self, name, host, user, password, nodeId):
         self._name = name


### PR DESCRIPTION
Annonced here : https://developers.home-assistant.io/blog/2020/05/14/entity-class-names/